### PR TITLE
Suspend thermal control by default

### DIFF
--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -115,6 +115,7 @@ max_ports=${5:-$max_ports_def}
 # Local constants
 pwm_noact=0
 pwm_max=1
+pwm_def_rpm=153
 pwm_max_rpm=255
 max_amb=120000
 untrusted_sensor=0
@@ -882,8 +883,8 @@ disable_zones_max_pwm() {
 			fi
 		fi
 	done
-	echo $pwm_max_rpm > $pwm
-	log_action_msg "Set fan speed to maximum"
+	echo $pwm_def_rpm > $pwm
+	log_action_msg "Set fan speed to 60% percent"
 }
 
 # Validate thermal configuration.

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -546,6 +546,7 @@ do_start()
 	connect_platform
 	backward_compatibility_link
 
+	echo 1 > $config_path/suspend
 	$THERMAL_CONTROL $thermal_type $max_tachos $max_psus&
 }
 


### PR DESCRIPTION
Suspend thermal control and set the default fan speed to 60%

Signed-off-by: Kevin Wang <kevinw@mellanox.com>